### PR TITLE
com.google.jsinterop:js-interop-annotations:2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,16 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.jsinterop</groupId>
+                <artifactId>js-interop-annotations</artifactId>
+                <version>2.0.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build/>
 
     <distributionManagement>


### PR DESCRIPTION
- Fixed junit-processor requiring 1.x